### PR TITLE
Remove 23/24 signup form

### DIFF
--- a/membership.md
+++ b/membership.md
@@ -5,20 +5,9 @@ author: 'Marko Jung'
 layout: page
 ---
 
-### Membership fees
+### How to join?
 
-Diving Student/Instructor Membership
-: £55 per annum [[Pay](https://lopay.app/1121f/315520fc-854c-4db8-b397-d247c1d75bae)]
-
-Diving Non-Student Membership
-: £77 per annum [[Pay](https://lopay.app/1121f/09c111f8-08fc-4567-b7ba-0353798a9b31)]
-
-*Prices maybe updated based on the cost and budget.*
-
-Payment can alternatively be made by bank transfer, see [here](/about/payments).
-
-You may be eligible to have your membership fee reimbursed by your college.
-Please check with your college if they have a sports grant scheme.
+Please see our [joining instructions](/membership/join) for the sign up process and payment instructions.
 
 ### Why join our club?
 
@@ -33,7 +22,6 @@ OUUEG is the official University of Oxford scuba diving sports club. You join a 
 - We are a very friendly, vibrant club with an extremely open and helpful membership.
 
 These are just a few of the perks we exclusively offer to our members. Please contact our [membership officer](mailto:membership@ouueg.com) if you have any questions prior joining the club.
-
 ## BSAC Membership
 
 **In addition** to OUUEG memberhsip, you need to be a member of BSAC, the national governing body of recreational diving in the United Kingdom. You can register or update your membership on the [**BSAC membership website**](https://www.bsac.com/membership/) by clicking “Join via club” and searching for OUUEG.

--- a/membership/join.md
+++ b/membership/join.md
@@ -9,16 +9,34 @@ We accept novices and already-qualified divers alike. If you’ve never dived be
 
 Regardless, start your underwater adventure by following these three easy steps. Any questions, then [get in contact](/about/contact).
 
-### 1. Register online with OUUEG
+### 1. Register with OUUEG
 
-Let the committee know you have joined OUUEG by filling out the form below or via [the link](https://forms.gle/1wX1bJWmMmgGuTZF6): <https://forms.gle/1wX1bJWmMmgGuTZF6>
+Let the Membership secretary know you have joined OUUEG by e-mail to membership@ouueg.com. Please copy the treasurer into you e-mail <treasurer@ouueg.com>.
 
-<iframe frameborder="0" height="3570" loading="lazy" marginheight="0" marginwidth="0" src="https://docs.google.com/forms/d/e/1FAIpQLSc4GdngsGhICmGEX2DWVuWid562VF_zYtv3yi4oanTqE4TSpA/viewform?embedded=true" width="640">Loading…</iframe>
-
-*Note*: If you have a problem filling out the form above, please email <treasurer@ouueg.com>:
-
-- Please CC secretary@ouueg.com and membership@ouueg.com
 - The subject line should be “NEW MEMBERSHIP \[NAME\] APP”
+
+You Email should include:
+
+1. First Name
+2. Last Name
+3. Contact Email Address
+4. If applicable, your university single sign-on (SSO)
+5. The type of your membership [Student (£55), Instructor (£55), Full (£77), Honorary]
+6. If you did a try dive and pay £30 please give the relevant date so we can check our records for the £30 membership discount.
+7. What is your University of Oxford affiliation [Stduent/Staff/Alumnus/No affiliation/other]
+8. Your BSAC membership number (if you already have one)
+9. If applicable, current diving qualification (e.g. PADI Open Water, BSAC Sports Diver, etc.)
+10. Are you a qualified instructor?
+11. Are you Nitrox qualified?
+12. Are you drysuit qualified?
+13. What is your Maximum Qualified Depth (m)?
+
+Please pay your membership fee via bank transfer to     
+
+    Account Name: Oxford University Underwater Exploration Group
+    Sort Code: 54-21-23
+    Account Number: 24555215
+    Reference: “[NAME] MEMBERSHIP APP”
 
 ### 2. Register online with BSAC
 


### PR DESCRIPTION
This PR:
1. [replaces the out-of-date 2023-2024 sign-up form with instructions to email the membership secretary](https://github.com/OUUEG/ouueg.github.io/commit/d0bcecb2579cfff3f76ed3424a67301636d550d2)
2. [removes the payment links in the membership section and refers to the joining instructions instead](https://github.com/OUUEG/ouueg.github.io/commit/2593281469a063874ff7b562e513a3a0ac50f087)